### PR TITLE
grub2: drop trailing space from saved entry

### DIFF
--- a/src/Core/GRUB2.pm
+++ b/src/Core/GRUB2.pm
@@ -1263,6 +1263,7 @@ sub GetSettings {
     my $saved_entry = `/usr/bin/grub2-editenv list|sed -n '/^saved_entry=/s/.*=//p'`;
 
     chomp $saved_entry;
+    $saved_entry =~ s/\s+$//;
     if ($saved_entry eq "") {
         $saved_entry = "0";
     }


### PR DESCRIPTION
was needed on a Tumbleweed system